### PR TITLE
Freeze smartcitizen connector version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "Orange3 >= 3.31.1",
         "pyodcollect >= 1.1.0",
         "mecoda-minka >= 1.3.1",
-        "smartcitizen-connector >= 0.2.0",
+        "smartcitizen-connector == 0.2.0",
         "pydantic >= 2.4.2",
         "pytest",
         "tabulate",


### PR DESCRIPTION
Avoid errors due to new versions of the connector incompatible with mecoda